### PR TITLE
Fix error when files are not found

### DIFF
--- a/index.js
+++ b/index.js
@@ -38,17 +38,21 @@ module.exports = function (options) {
 
     // Inject includePath for relative includes
     opts.includePath = opts.includePath || path.dirname(opts.filename);
-
-    aglio.render(str, opts, function (err, html) {
-      if (err) {
-        self.emit('error', new PluginError('gulp-aglio', err));
-      } else {
-        file.contents = new Buffer(html);
-        file.path = gutil.replaceExtension(file.path, '.html');
-        self.push(file);
-      }
-      next();
-    });
+    
+    try {
+      aglio.render(str, opts, function (err, html) {
+        if (err) {
+          self.emit('error', new PluginError('gulp-aglio', err));
+        } else {
+          file.contents = new Buffer(html);
+          file.path = gutil.replaceExtension(file.path, '.html');
+          self.push(file);
+        }
+        next();
+      });
+    } catch(err) {
+      self.emit("error", new PluginError("gulp-aglio", err));
+    }
   }
 
   return through2.obj(transform);

--- a/index.js
+++ b/index.js
@@ -51,7 +51,7 @@ module.exports = function (options) {
         next();
       });
     } catch(err) {
-      self.emit("error", new PluginError("gulp-aglio", err));
+      self.emit('error', new PluginError('gulp-aglio', err));
     }
   }
 


### PR DESCRIPTION
Using include syntax with a wrong path to a file resulted in a crash without emitting an error message.

For instance:

Imagine you have a file named `authentication.apib` and you write :

```<!-- include(autentication.apib) -->``` without the `h`.

The gulp task finishes with an error. However, the event on('error,....) is never triggered making impossible to handle the error.